### PR TITLE
Improve performance by wrapping .find() with useMemo to avoid repeated scans of large items array on every render. selectedItem now recomputes only when items changes.

### DIFF
--- a/src/memo/MemoDemo.tsx
+++ b/src/memo/MemoDemo.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { initialItems } from "./utils";
 
@@ -15,8 +15,10 @@ const MemoDemo: React.FC<DemoProps> = ({}) => {
   const [count, setCount] = useState(0);
   const [items] = useState<Item[]>(initialItems);
 
-
-  const selectedItem = items.find((item) => item.isSelected);
+  const selectedItem = useMemo(
+    () => items.find((item) => item.isSelected),
+    [items]
+  );
 
   return (
     <div>


### PR DESCRIPTION
Improve performance by wrapping .find() with useMemo to avoid repeated scans of large items array on every render. selectedItem now recomputes only when items changes.
