### PR TITLE
feat: expose reset functionality in Counter component using forwardRef and useImperativeHandle

### DIFF
--- a/src/useImperative/Counter.tsx
+++ b/src/useImperative/Counter.tsx
@@ -1,6 +1,20 @@
-import React, { useState } from "react";
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+/* eslint-disable no-empty-pattern */
 
-const Counter = () => {
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useState,
+  type Ref,
+} from "react";
+
+interface CounterProps {}
+
+export type CounterRef = {
+  reset: () => void;
+};
+
+const Counter = ({}: CounterProps, ref: Ref<CounterRef>) => {
   const [count, setCount] = useState(0);
 
   const increment = () => {
@@ -15,6 +29,11 @@ const Counter = () => {
   const reset = () => {
     setCount(0);
   };
+
+  useImperativeHandle(ref, () => ({
+    reset,
+  }));
+
   return (
     <div>
       <h1 className="text-2xl">Count: {count}</h1>
@@ -24,4 +43,4 @@ const Counter = () => {
   );
 };
 
-export default Counter;
+export default forwardRef(Counter);

--- a/src/useImperative/UseImperativeDemo.tsx
+++ b/src/useImperative/UseImperativeDemo.tsx
@@ -1,13 +1,18 @@
 /* eslint-disable no-empty-pattern */
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-import React from "react";
-import Counter from "./Counter";
+import React, { useRef } from "react";
+import Counter, { type CounterRef } from "./Counter";
 
 interface UseImperativeDemoProps {}
+
 const UseImperativeDemo: React.FC<UseImperativeDemoProps> = ({}) => {
+  const counterRef = useRef<CounterRef>(null);
   return (
     <div>
-      <Counter />
+      <Counter ref={counterRef} />
+      <button onClick={() => counterRef.current?.reset()}>
+        Reset From Parent
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
- Refactored Counter to accept a forwarded ref
- Used useImperativeHandle to expose a reset method to parent components
- Allows external control of count state without modifying Counter directly