### PR TITLE
feat: implement custom TextInput with reset method via forwardRef and useImperativeHandle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import "./App.css";
-import UseImperativeDemo from "./useImperative/UseImperativeDemo";
+import UseImperativeDemo2 from "./useImperative/UseImperativeDemo2";
 
 function App() {
   return (
@@ -9,7 +9,8 @@ function App() {
       {/* <CallbackDemo /> */}
       {/* <UseRefDemo /> */}
       {/* <UseRefDemo2 /> */}
-      <UseImperativeDemo />
+      {/* <UseImperativeDemo /> */}
+      <UseImperativeDemo2 />
     </>
   );
 }

--- a/src/useImperative/TextInput.tsx
+++ b/src/useImperative/TextInput.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable no-empty-pattern */
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  type Ref,
+} from "react";
+
+interface TextInputProps {}
+
+export type TextInputRef = {
+  reset: () => void;
+};
+const TextInput = ({}: TextInputProps, ref: Ref<TextInputProps>) => {
+  const localRef = useRef<HTMLInputElement | null>(null);
+  useImperativeHandle(ref, () => ({
+    reset: () => {
+      if (!localRef.current) return;
+      localRef.current.value = "";
+      localRef.current.focus();
+    },
+  }));
+  return <input type="text" ref={localRef} />;
+};
+
+export default forwardRef(TextInput);

--- a/src/useImperative/UseImperativeDemo2.tsx
+++ b/src/useImperative/UseImperativeDemo2.tsx
@@ -1,0 +1,17 @@
+import React, { useRef } from "react";
+import TextInput, { type TextInputRef } from "./TextInput";
+
+const UseImperativeDemo2 = () => {
+  const inputRef = useRef<TextInputRef>(null);
+
+  return (
+    <>
+      <TextInput ref={inputRef} />
+      <button onClick={() => inputRef.current?.reset()}>
+        Reset From Parent
+      </button>
+    </>
+  );
+};
+
+export default UseImperativeDemo2;


### PR DESCRIPTION
- Created a reusable TextInput component that exposes a reset() method to parent via useImperativeHandle
- Used forwardRef to allow parent access to internal input ref
- Parent component demonstrates how to trigger reset from outside the child